### PR TITLE
Feature/upload handler changes

### DIFF
--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -1685,6 +1685,7 @@ class ScenarioUploadHandler(BaseHandler):
         except Exception as ex:
             self.send_error(status_code=400,
                             reason=ex)
+            return
         scenario_name_key = cache.scenario_key_name(scenario)
 
         # prepare stub payload

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -1709,7 +1709,12 @@ class ScenarioUploadHandler(BaseHandler):
 
         # if there are any stubs - creating a session
         if stub_list:
-            cache.create_session_cache(scenario, session)
+            try:
+                cache.create_session_cache(scenario, session)
+            except Exception as ex:
+                msg = "Failed to begin session for scenario %s, session %s. Got error: %s" % (scenario, session, ex)
+                log.warn(msg)
+                status.append(msg)
 
         result = {
             "scenario": scenario,

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -1637,6 +1637,11 @@ class ScenarioUploadHandler(BaseHandler):
         found = False
 
         for f in reversed(files):
+            # collecting stub files
+            if f.endswith(".json"):
+                stub_list.append(f)
+
+            # looking for configuration file
             if f.endswith(".yaml"):
                 # reading yaml file
                 with open(tmp_dir + "/" + f, 'r') as stream:
@@ -1645,8 +1650,6 @@ class ScenarioUploadHandler(BaseHandler):
                         config = yaml.load(stream)
                         session = config['recording'].get('session', session)
                         scenario = config['recording'].get('scenario', scenario)
-                        stub_list = config['recording'].get('stubs', stub_list)
-
                     except Exception as ex:
                         self.send_error(400, reason="Configuration file found, however, "
                                                     "failed to read it. Got error: %s" % ex)
@@ -1691,7 +1694,7 @@ class ScenarioUploadHandler(BaseHandler):
         status = []
 
         for stub in stub_list:
-            full_file_name = tmp_dir + "/" + stub['file']
+            full_file_name = tmp_dir + "/" + stub
             try:
                 with open(full_file_name) as data_file:
                     data = json.load(data_file)

--- a/stubo/service/tests/test_api_v2.py
+++ b/stubo/service/tests/test_api_v2.py
@@ -903,39 +903,6 @@ class TestStubOperations(Base):
         # response code should be 400 (bad request)
         self.assertEquals(response.code, 415)
 
-    def test_upload_missing_stub(self):
-        """
-
-        Testing /api/v2/scenarios/upload handler, supplying config with one missing file
-        """
-        # getting file
-        stubo_dir = stubo_path()
-
-        test_file = os.path.join(stubo_dir, 'static/cmds/tests/upload/scenario_missing_stub.zip')
-        f = open(test_file)
-
-        files = [('files', ('scenario_100', f, 'application/zip'))]
-
-        data = {}
-        a = requests.Request(url="http://not_important/",
-                             files=files, data=data)
-        prepare = a.prepare()
-        f.close()
-
-        content_type = prepare.headers.get('Content-Type')
-        body = prepare.body
-
-        url = "/api/v2/scenarios/upload"
-        headers = {
-            "Content-Type": content_type,
-        }
-
-        response = self.fetch(url, method='POST', body=body, headers=headers)
-
-        # response code should be 200 (config read successfully however status about failure should appear)
-        self.assertEquals(response.code, 200)
-        self.assertTrue("Failed to process request/response scenario_100_1445435070_0_missing.json."
-                        " Got error: [Errno 2] No such file or directory" in response.body)
 
     def test_upload_missing_config(self):
         """

--- a/stubo/service/tests/test_api_v2.py
+++ b/stubo/service/tests/test_api_v2.py
@@ -415,6 +415,7 @@ class TestSessionOperations(Base):
         # checking whether 10 sessions were affected
         self.assertEqual(len(json.loads(response.body)['data']), 10)
 
+
 class TestDelayOperations(Base):
     """
     Test case for testing delay operations (add, update, delete)
@@ -902,7 +903,6 @@ class TestStubOperations(Base):
 
         # response code should be 400 (bad request)
         self.assertEquals(response.code, 415)
-
 
     def test_upload_missing_config(self):
         """

--- a/stubo/static/dist/manageScenarios-bundle.js
+++ b/stubo/static/dist/manageScenarios-bundle.js
@@ -243,7 +243,7 @@ webpackJsonp([5],[
 	            null,
 	            'Remove scenario.'
 	        );
-	        if (this.state.session != "dormant") {
+	        if (this.state.session == "playback" || this.state.session == "record") {
 	            return _react2['default'].createElement(
 	                _reactBootstrap.Button,
 	                { bsStyle: 'danger', bsSize: 'small', disabled: true },

--- a/stubo/static/src/manageScenarios.jsx
+++ b/stubo/static/src/manageScenarios.jsx
@@ -207,7 +207,7 @@ var RemoveButton = React.createClass({
         const RemoveTooltip = (
             <Tooltip>Remove scenario.</Tooltip>
         );
-        if (this.state.session != "dormant") {
+        if (this.state.session == "playback" || this.state.session == "record") {
             return (
                 <Button bsStyle='danger' bsSize='small' disabled>
                     <span className="glyphicon glyphicon-remove-sign"></span>


### PR DESCRIPTION
changed how mirage /api/v2/scenarios/upload handler treats .yaml configuration files. Now it only reads scenario and session names. All archived .json files will be treated as stubs and will be imported under the same scenario. This will make easier to generate initial test data since you won't have to updated .yaml configuration file with each created stub file.